### PR TITLE
Fix discovery of FSL's PATH in calls to FLIRT

### DIFF
--- a/clindmri/extensions/configuration.py
+++ b/clindmri/extensions/configuration.py
@@ -35,6 +35,7 @@ def environment(sh_file=None, env={}):
     # we're using shell=True
     # Pass empty environment to get only the prgram variables
     command = ["bash", "-c", ". '{0}' ; /usr/bin/printenv".format(sh_file)]
+    env['PATH'] = os.environ['PATH']
     process = subprocess.Popen(command, env=env,
                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = process.communicate()

--- a/clindmri/registration/fsl/flirt.py
+++ b/clindmri/registration/fsl/flirt.py
@@ -16,7 +16,8 @@ from clindmri.extensions.fsl.exceptions import FSLRuntimeError
 
 def flirt(in_file, ref_file, omat=None, out=None, init=None, cost="corratio",
           usesqform=None, displayinit=None, anglerep="euler", bins=256,
-          interp="trilinear", dof=12, applyxfm=None, verbose=0):
+          interp="trilinear", dof=12, applyxfm=None, verbose=0,
+          shfile="/etc/fsl/5.0/fsl.sh"):
     """ Wraps command flirt.
 
     Usage: flirt [options] -in <inputvol> -ref <refvol> -out <outputvol>
@@ -133,7 +134,7 @@ def flirt(in_file, ref_file, omat=None, out=None, init=None, cost="corratio",
         omat = os.path.join(dirname, "flirt_omat_{0}".format(basename))
 
     # Call flirt
-    fslprocess = FSLWrapper("flirt")
+    fslprocess = FSLWrapper("flirt", shfile=shfile)
     fslprocess()
     if fslprocess.exitcode != 0:
         raise FSLRuntimeError(fslprocess.cmd[0], " ".join(fslprocess.cmd[1:]),


### PR DESCRIPTION
Hi @AGrigis, while trying to use `qmri` I had problems passing the path to FSL to the `registration.fsl.flirt` function. Here is a fix :slightly_smiling_face: 